### PR TITLE
청년관 네비 필요없는거 줄이고, 청년관 메인페이지 삭제 및 바로 일자리 페이지 뜨게 연결함

### DIFF
--- a/src/main/MainPage.js
+++ b/src/main/MainPage.js
@@ -254,7 +254,7 @@ function MainPage() {
             </motion.div>
           )}
           <div className="mt-2 sm:w-[521px] w-[260.5px] h-[270px] sm:ml-[0px] ml-[10px] flex flex-wrap gap-4 text-white font-bold ">
-            <Link to="/youth">
+            <Link to="/youth/job">
               <div className="text-2xl sm:w-[250px] w-[120px] h-[150px] bg-[linear-gradient(45deg,_#0130BC,_#6E00FF)]  flex justify-center items-center hover:text-gray-300 hover:scale-90 transition duration-500">
                 청년관
               </div>

--- a/src/youth/YouthPage.js
+++ b/src/youth/YouthPage.js
@@ -9,9 +9,6 @@ function YouthPage() {
     { name: "주거", link: "house" },
     { name: "복지", link: "welfare" },
     { name: "교육", link: "education" },
-    { name: "창업", link: "" },
-    { name: "지도", link: "" },
-    { name: "건의", link: "" },
   ];
 
   return (

--- a/src/youth/education/EducationPage.js
+++ b/src/youth/education/EducationPage.js
@@ -17,7 +17,7 @@ const EducationPage = () => {
   const [selectedCategory, setSelectedCategory] = useState("전체"); // 선택된 카테고리 상태
 
   // 페이징을 위한 값들
-  const pageSize = 5; 
+  const pageSize = 10; 
   const pagesPerGroup = 10; 
   const currentPage = (parseInt(searchParams.get("page")) || 1) - 1; 
   const currentPageGroup = Math.floor(currentPage / pagesPerGroup);

--- a/src/youth/welfare/WelfarePage.js
+++ b/src/youth/welfare/WelfarePage.js
@@ -17,7 +17,7 @@ const WelfarePage = () => {
   const [selectedCategory, setSelectedCategory] = useState("전체"); // 선택된 카테고리 상태
 
   // 페이징을 위한 값들
-  const pageSize = 5; 
+  const pageSize = 10; 
   const pagesPerGroup = 10; 
   const currentPage = (parseInt(searchParams.get("page")) || 1) - 1; 
   const currentPageGroup = Math.floor(currentPage / pagesPerGroup);


### PR DESCRIPTION
청년관 변경점
1. 네비에서 창업/지도/건의 삭제
2. 청년관 메인 페이지 없어지고 바로 일자리 페이지로 이동